### PR TITLE
Urlauth

### DIFF
--- a/src/tests/urlauth-binary
+++ b/src/tests/urlauth-binary
@@ -18,6 +18,8 @@ ok GENURLAUTH "imap://$username@$domain/$mailbox_url/;uid=$uid2/;section=1;urlau
 * GENURLAUTH $mail_url2
 ok GENURLAUTH "imap://$username@$domain/$mailbox_url/;uid=$uid2/;section=1.1;urlauth=user+$user" INTERNAL
 * GENURLAUTH $mail_url2sub
+ok GENURLAUTH "imap://$username@$domain/$mailbox_url/;uid=$uid2/;section=1.2;urlauth=user+$user" INTERNAL
+* GENURLAUTH $mail_url2sub2
 
 ok URLFETCH ($mail_url1 binary)
 * URLFETCH $mail_url1 (binary {{{
@@ -100,5 +102,10 @@ hello world
 
 ok URLFETCH ($mail_url2sub binary bodypartstructure)
 * URLFETCH $mail_url2sub (BODYPARTSTRUCTURE ("text" "x-myown" ("charset" "us-ascii") NIL NIL "7bit" 11 0 NIL NIL NIL NIL)) (BINARY {{{
+hello world
+}}})
+
+ok URLFETCH ($mail_url2sub2 binary bodypartstructure)
+* URLFETCH $mail_url2sub2 (BODYPARTSTRUCTURE ("text" "x-myown" ("charset" "us-ascii") NIL NIL "7bit" 11 0 NIL NIL NIL NIL)) (BINARY {{{
 hello world
 }}})

--- a/src/tests/urlauth-binary
+++ b/src/tests/urlauth-binary
@@ -29,14 +29,22 @@ Content-Type: multipart/alternative; boundary="sub1"
 Sub MIME prologue
 --sub1
 Content-Type: text/x-myown; charset=us-ascii
-Content-Transfer-Encoding: binary
+Content-Transfer-Encoding: base64
 
-hello world
+aGVs
+bG8gd29y
+bGQ=
+
 --sub1
 Content-Type: text/x-myown; charset=us-ascii
-Content-Transfer-Encoding: binary
+Content-Transfer-Encoding: base64
 
-hello world
+  aGVs    
+ bG8g  
+   d29y  	 
+    bGQ= 
+
+
 --sub1--
 Sub MIME epilogue
 
@@ -55,7 +63,7 @@ ok URLFETCH ($mail_url1sub bodypartstructure)
 
 
 ok URLFETCH ($mail_url2 binary bodypartstructure)
-* URLFETCH $mail_url2 (BODYPARTSTRUCTURE ("message" "rfc822" NIL NIL NIL "7bit" 390 ("Sun, 12 Aug 2012 12:34:56 +0300" "submsg" ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) NIL NIL NIL NIL NIL) (("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 11 0 NIL NIL NIL NIL)("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 11 0 NIL NIL NIL NIL) "alternative" ("boundary" "sub1") NIL NIL NIL) 18 NIL NIL NIL NIL) binary {{{
+* URLFETCH $mail_url2 (BODYPARTSTRUCTURE ("message" "rfc822" NIL NIL NIL "7bit" 437 ("Sun, 12 Aug 2012 12:34:56 +0300" "submsg" ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) NIL NIL NIL NIL NIL) (("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 22 3 NIL NIL NIL NIL)("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 47 5 NIL NIL NIL NIL) "alternative" ("boundary" "sub1") NIL NIL NIL) 26 NIL NIL NIL NIL)) (BINARY {{{
 From: sub@domain.org
 Date: Sun, 12 Aug 2012 12:34:56 +0300
 Subject: submsg
@@ -64,14 +72,22 @@ Content-Type: multipart/alternative; boundary="sub1"
 Sub MIME prologue
 --sub1
 Content-Type: text/x-myown; charset=us-ascii
-Content-Transfer-Encoding: binary
+Content-Transfer-Encoding: base64
 
-hello world
+aGVs
+bG8gd29y
+bGQ=
+
 --sub1
 Content-Type: text/x-myown; charset=us-ascii
-Content-Transfer-Encoding: binary
+Content-Transfer-Encoding: base64
 
-hello world
+  aGVs    
+ bG8g  
+   d29y  	 
+    bGQ= 
+
+
 --sub1--
 Sub MIME epilogue
 
@@ -83,6 +99,6 @@ hello world
 }}})
 
 ok URLFETCH ($mail_url2sub binary bodypartstructure)
-* URLFETCH $mail_url2sub (BODYPARTSTRUCTURE ("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 11 0 NIL NIL NIL NIL) BINARY {{{
+* URLFETCH $mail_url2sub (BODYPARTSTRUCTURE ("text" "x-myown" ("charset" "us-ascii") NIL NIL "7bit" 11 0 NIL NIL NIL NIL)) (BINARY {{{
 hello world
 }}})

--- a/src/tests/urlauth-binary
+++ b/src/tests/urlauth-binary
@@ -22,6 +22,8 @@ ok GENURLAUTH "imap://$username@$domain/$mailbox_url/;uid=$uid2/;section=1.2;url
 * GENURLAUTH $mail_url2sub2
 ok GENURLAUTH "imap://$username@$domain/$mailbox_url/;uid=$uid2/;section=1.3;urlauth=user+$user" INTERNAL
 * GENURLAUTH $mail_url2sub3
+ok GENURLAUTH "imap://$username@$domain/$mailbox_url/;uid=$uid2/;section=1.4;urlauth=user+$user" INTERNAL
+* GENURLAUTH $mail_url2sub4
 
 ok URLFETCH ($mail_url1 binary)
 * URLFETCH $mail_url1 (binary {{{
@@ -55,6 +57,16 @@ Content-Transfer-Encoding: x-unprintable
 
 nothing to see here
 
+--sub1
+Content-Type: text/plain; charset=us-ascii
+Content-Transfer-Encoding: quoted-printable
+
+definitely nothing to see here
+
+--=
+sub=
+=31--
+
 --sub1--
 Sub MIME epilogue
 
@@ -66,14 +78,14 @@ hello world
 }}})
 
 ok URLFETCH ($mail_url1 bodypartstructure)
-* URLFETCH $mail_url1 (BODYPARTSTRUCTURE ("message" "rfc822" NIL NIL NIL "7bit" 558 ("Sun, 12 Aug 2012 12:34:56 +0300" "submsg" ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) NIL NIL NIL NIL NIL) (("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 22 3 NIL NIL NIL NIL)("text" "x-myother" ("charset" "us-ascii") NIL NIL "base64" 47 5 NIL NIL NIL NIL)("text" "plain" ("charset" "us-ascii") NIL NIL "x-unprintable" 21 1 NIL NIL NIL NIL) "alternative" ("boundary" "sub1") NIL NIL NIL) 32 NIL NIL NIL NIL))
+* URLFETCH $mail_url1 (BODYPARTSTRUCTURE ("message" "rfc822" NIL NIL NIL "7bit" 711 ("Sun, 12 Aug 2012 12:34:56 +0300" "submsg" ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) NIL NIL NIL NIL NIL) (("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 22 3 NIL NIL NIL NIL)("text" "x-myother" ("charset" "us-ascii") NIL NIL "base64" 47 5 NIL NIL NIL NIL)("text" "plain" ("charset" "us-ascii") NIL NIL "x-unprintable" 21 1 NIL NIL NIL NIL)("text" "plain" ("charset" "us-ascii") NIL NIL "quoted-printable" 52 5 NIL NIL NIL NIL) "alternative" ("boundary" "sub1") NIL NIL NIL) 42 NIL NIL NIL NIL))
 
 ok URLFETCH ($mail_url1sub bodypartstructure)
 * URLFETCH $mail_url1sub (BODYPARTSTRUCTURE ("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 22 3 NIL NIL NIL NIL))
 
 
 ok URLFETCH ($mail_url2 binary bodypartstructure)
-* URLFETCH $mail_url2 (BODYPARTSTRUCTURE ("message" "rfc822" NIL NIL NIL "7bit" 558 ("Sun, 12 Aug 2012 12:34:56 +0300" "submsg" ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) NIL NIL NIL NIL NIL) (("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 22 3 NIL NIL NIL NIL)("text" "x-myother" ("charset" "us-ascii") NIL NIL "base64" 47 5 NIL NIL NIL NIL)("text" "plain" ("charset" "us-ascii") NIL NIL "x-unprintable" 21 1 NIL NIL NIL NIL) "alternative" ("boundary" "sub1") NIL NIL NIL) 32 NIL NIL NIL NIL)) (BINARY {{{
+* URLFETCH $mail_url2 (BODYPARTSTRUCTURE ("message" "rfc822" NIL NIL NIL "7bit" 711 ("Sun, 12 Aug 2012 12:34:56 +0300" "submsg" ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) NIL NIL NIL NIL NIL) (("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 22 3 NIL NIL NIL NIL)("text" "x-myother" ("charset" "us-ascii") NIL NIL "base64" 47 5 NIL NIL NIL NIL)("text" "plain" ("charset" "us-ascii") NIL NIL "x-unprintable" 21 1 NIL NIL NIL NIL)("text" "plain" ("charset" "us-ascii") NIL NIL "quoted-printable" 52 5 NIL NIL NIL NIL) "alternative" ("boundary" "sub1") NIL NIL NIL) 42 NIL NIL NIL NIL)) (BINARY {{{
 From: sub@domain.org
 Date: Sun, 12 Aug 2012 12:34:56 +0300
 Subject: submsg
@@ -104,6 +116,16 @@ Content-Transfer-Encoding: x-unprintable
 
 nothing to see here
 
+--sub1
+Content-Type: text/plain; charset=us-ascii
+Content-Transfer-Encoding: quoted-printable
+
+definitely nothing to see here
+
+--=
+sub=
+=31--
+
 --sub1--
 Sub MIME epilogue
 
@@ -126,3 +148,11 @@ hello world
 
 ok URLFETCH ($mail_url2sub3 binary bodypartstructure)
 * URLFETCH $mail_url2sub3 (BODYPARTSTRUCTURE ("text" "plain" ("charset" "us-ascii") NIL NIL "x-unprintable" 21 1 NIL NIL NIL NIL)) (BINARY NIL)
+
+ok URLFETCH ($mail_url2sub4 binary bodypartstructure)
+* URLFETCH $mail_url2sub4 (BODYPARTSTRUCTURE ("text" "plain" ("charset" "us-ascii") NIL NIL "7bit" 44 0 NIL NIL NIL NIL)) (BINARY {{{
+definitely nothing to see here
+
+--sub1--
+
+}}})

--- a/src/tests/urlauth-binary
+++ b/src/tests/urlauth-binary
@@ -20,6 +20,8 @@ ok GENURLAUTH "imap://$username@$domain/$mailbox_url/;uid=$uid2/;section=1.1;url
 * GENURLAUTH $mail_url2sub
 ok GENURLAUTH "imap://$username@$domain/$mailbox_url/;uid=$uid2/;section=1.2;urlauth=user+$user" INTERNAL
 * GENURLAUTH $mail_url2sub2
+ok GENURLAUTH "imap://$username@$domain/$mailbox_url/;uid=$uid2/;section=1.3;urlauth=user+$user" INTERNAL
+* GENURLAUTH $mail_url2sub3
 
 ok URLFETCH ($mail_url1 binary)
 * URLFETCH $mail_url1 (binary {{{
@@ -38,7 +40,7 @@ bG8gd29y
 bGQ=
 
 --sub1
-Content-Type: text/x-myown; charset=us-ascii
+Content-Type: text/x-myother; charset=us-ascii
 Content-Transfer-Encoding: base64
 
   aGVs    
@@ -46,6 +48,12 @@ Content-Transfer-Encoding: base64
    d29y  	 
     bGQ= 
 
+
+--sub1
+Content-Type: text/plain; charset=us-ascii
+Content-Transfer-Encoding: x-unprintable
+
+nothing to see here
 
 --sub1--
 Sub MIME epilogue
@@ -58,14 +66,14 @@ hello world
 }}})
 
 ok URLFETCH ($mail_url1 bodypartstructure)
-* URLFETCH $mail_url1 (BODYPARTSTRUCTURE ("message" "rfc822" NIL NIL NIL "7bit" 437 ("Sun, 12 Aug 2012 12:34:56 +0300" "submsg" ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) NIL NIL NIL NIL NIL) (("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 22 3 NIL NIL NIL NIL)("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 47 5 NIL NIL NIL NIL) "alternative" ("boundary" "sub1") NIL NIL NIL) 26 NIL NIL NIL NIL))
+* URLFETCH $mail_url1 (BODYPARTSTRUCTURE ("message" "rfc822" NIL NIL NIL "7bit" 558 ("Sun, 12 Aug 2012 12:34:56 +0300" "submsg" ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) NIL NIL NIL NIL NIL) (("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 22 3 NIL NIL NIL NIL)("text" "x-myother" ("charset" "us-ascii") NIL NIL "base64" 47 5 NIL NIL NIL NIL)("text" "plain" ("charset" "us-ascii") NIL NIL "x-unprintable" 21 1 NIL NIL NIL NIL) "alternative" ("boundary" "sub1") NIL NIL NIL) 32 NIL NIL NIL NIL))
 
 ok URLFETCH ($mail_url1sub bodypartstructure)
 * URLFETCH $mail_url1sub (BODYPARTSTRUCTURE ("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 22 3 NIL NIL NIL NIL))
 
 
 ok URLFETCH ($mail_url2 binary bodypartstructure)
-* URLFETCH $mail_url2 (BODYPARTSTRUCTURE ("message" "rfc822" NIL NIL NIL "7bit" 437 ("Sun, 12 Aug 2012 12:34:56 +0300" "submsg" ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) NIL NIL NIL NIL NIL) (("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 22 3 NIL NIL NIL NIL)("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 47 5 NIL NIL NIL NIL) "alternative" ("boundary" "sub1") NIL NIL NIL) 26 NIL NIL NIL NIL)) (BINARY {{{
+* URLFETCH $mail_url2 (BODYPARTSTRUCTURE ("message" "rfc822" NIL NIL NIL "7bit" 558 ("Sun, 12 Aug 2012 12:34:56 +0300" "submsg" ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) ((NIL NIL "sub" "domain.org")) NIL NIL NIL NIL NIL) (("text" "x-myown" ("charset" "us-ascii") NIL NIL "base64" 22 3 NIL NIL NIL NIL)("text" "x-myother" ("charset" "us-ascii") NIL NIL "base64" 47 5 NIL NIL NIL NIL)("text" "plain" ("charset" "us-ascii") NIL NIL "x-unprintable" 21 1 NIL NIL NIL NIL) "alternative" ("boundary" "sub1") NIL NIL NIL) 32 NIL NIL NIL NIL)) (BINARY {{{
 From: sub@domain.org
 Date: Sun, 12 Aug 2012 12:34:56 +0300
 Subject: submsg
@@ -81,7 +89,7 @@ bG8gd29y
 bGQ=
 
 --sub1
-Content-Type: text/x-myown; charset=us-ascii
+Content-Type: text/x-myother; charset=us-ascii
 Content-Transfer-Encoding: base64
 
   aGVs    
@@ -89,6 +97,12 @@ Content-Transfer-Encoding: base64
    d29y  	 
     bGQ= 
 
+
+--sub1
+Content-Type: text/plain; charset=us-ascii
+Content-Transfer-Encoding: x-unprintable
+
+nothing to see here
 
 --sub1--
 Sub MIME epilogue
@@ -106,6 +120,9 @@ hello world
 }}})
 
 ok URLFETCH ($mail_url2sub2 binary bodypartstructure)
-* URLFETCH $mail_url2sub2 (BODYPARTSTRUCTURE ("text" "x-myown" ("charset" "us-ascii") NIL NIL "7bit" 11 0 NIL NIL NIL NIL)) (BINARY {{{
+* URLFETCH $mail_url2sub2 (BODYPARTSTRUCTURE ("text" "x-myother" ("charset" "us-ascii") NIL NIL "7bit" 11 0 NIL NIL NIL NIL)) (BINARY {{{
 hello world
 }}})
+
+ok URLFETCH ($mail_url2sub3 binary bodypartstructure)
+* URLFETCH $mail_url2sub3 (BODYPARTSTRUCTURE ("text" "plain" ("charset" "us-ascii") NIL NIL "x-unprintable" 21 1 NIL NIL NIL NIL)) (BINARY NIL)

--- a/src/tests/urlauth-binary.mbox
+++ b/src/tests/urlauth-binary.mbox
@@ -40,6 +40,16 @@ Content-Transfer-Encoding: x-unprintable
 
 nothing to see here
 
+--sub1
+Content-Type: text/plain; charset=us-ascii
+Content-Transfer-Encoding: quoted-printable
+
+definitely nothing to see here
+
+--=
+sub=
+=31--
+
 --sub1--
 Sub MIME epilogue
 

--- a/src/tests/urlauth-binary.mbox
+++ b/src/tests/urlauth-binary.mbox
@@ -25,7 +25,7 @@ bG8gd29y
 bGQ=
 
 --sub1
-Content-Type: text/x-myown; charset=us-ascii
+Content-Type: text/x-myother; charset=us-ascii
 Content-Transfer-Encoding: base64
 
   aGVs    
@@ -33,6 +33,12 @@ Content-Transfer-Encoding: base64
    d29y  	 
     bGQ= 
 
+
+--sub1
+Content-Type: text/plain; charset=us-ascii
+Content-Transfer-Encoding: x-unprintable
+
+nothing to see here
 
 --sub1--
 Sub MIME epilogue


### PR DESCRIPTION
This is a series of 4 patches.

The first one just changes the urlauth-binary tests to match my reading of what the spec actually intends.

In particular the existing tests are clearly bogus because they look for a BODYPARTSTRUCTURE which still says that the encoding is BASE64, while the BODYPARTSTRUCTURE is supposed to represent the converted data and the encoding should contain the identity domain of the BINARY content if BINARY is requested.

The second patch just adds a boring additional test.

The third adds a test for the case of an unparseable part, to make sure that the server returns the original bodystructure and a NIL BINARY part.

The fourth adds a part with a quoted-printable encoded version of the MIME boundary, which would cause broken results from a server which blindly decodes each individual part without checking for boundaries in the resulting MIME structure.