### PR TITLE
Skip nonauth tests when missing capability

### DIFF
--- a/src/test-exec.c
+++ b/src/test-exec.c
@@ -1127,7 +1127,10 @@ static int test_send_lstate_commands(struct client *_client)
 		   done in init_callback to make sure that all commands have
 		   been finished before starting the test. */
 		if (ctx->test->startup_state != TEST_STARTUP_STATE_SELECTED) {
-			if (--ctx->clients_waiting == 0)
+			if (ctx->test->startup_state == TEST_STARTUP_STATE_NONAUTH &&
+			    !test_have_all_capabilities(client))
+				test_skip(ctx);
+			else if (--ctx->clients_waiting == 0)
 				test_send_first_command(ctx);
 			else if (client == ctx->clients[0])
 				wakeup_clients(ctx);


### PR DESCRIPTION
This fixes src/tests/id on a server which doesn't support the ID extension.

For some reason the test is skipped but not counted as such:

```
1 test groups: 0 failed, 0 skipped due to missing capabilities
base protocol: 0/0 individual commands failed
extensions: 0/0 individual commands failed
```