### PR TITLE
mailbox: Show malformed envelope on parsing error.

### DIFF
--- a/src/mailbox.c
+++ b/src/mailbox.c
@@ -786,7 +786,7 @@ mailbox_global_parse_envelope(struct mailbox_source *source,
 	msg->subject_utf8_tcase = NULL;
 	if (!imap_envelope_parse(msg->envelope,
 		pool_datastack_create(), &env, &error)) {
-		i_error("Error parsing IMAP envelope: %s", error);
+		i_error("Error parsing IMAP envelope: %s (%s)", error, msg->envelope);
 		return FALSE;
 	}
 	subject = env->subject;


### PR DESCRIPTION
If the tester detects the IMAP envelope is malformed, it indicates this, but unlike most other errors, it doesn't show the response that triggered the failure. The malformed envelope is now printed out for easier debugging.