### PR TITLE
Build and publish a static imaptest version on repo push

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,80 @@
+name: Build static version of imaptest
+
+on:
+  pull_request:
+  push:
+    paths:
+      - 'src/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout imaptest
+        uses: actions/checkout@v4
+        with:
+          path: imaptest
+      - name: Checkout dovecot
+        uses: actions/checkout@v4
+        with:
+          repository: dovecot/core
+          path: core
+      - name: Install gettext (missing from GH Actions image)
+        run: |
+          sudo apt install -y gettext
+      - name: Build dovecot libraries
+        working-directory: ${{ github.workspace }}/core
+        run: |
+          ./autogen.sh
+          ./configure --without-shared-libs
+          make
+      - name: Build imaptest
+        working-directory: ${{ github.workspace }}/imaptest
+        run: |
+          ./autogen.sh
+          ./configure --with-dovecot=../core --enable-static
+          make
+      - name: Upload Artifact
+        if: ${{ github.repository == 'dovecot/imaptest' && github.ref == 'refs/heads/main' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: imaptest
+          path: imaptest/src/imaptest
+  publish:
+    needs: build
+    if: ${{ github.repository == 'dovecot/imaptest' && github.ref == 'refs/heads/main' }}
+    name: Publish
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: imaptest
+          path: ./
+      - name: Make imaptest executable
+        run: |
+          chmod +x imaptest
+      - name: TAR/GZ imaptest
+        run: |
+          tar czfv imaptest.tgz imaptest
+      - name: Generate SHA256 checksum
+        run: |
+          sha256sum imaptest.tgz > SHA256SUMS.txt
+      - name: List files
+        run: ls -rl
+      - name: Update latest Release
+        uses: andelf/nightly-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: latest
+          name: 'ImapTest Latest Release'
+          draft: false
+          body: |
+            This is a static binary of imaptest (built on Ubuntu 22.04).
+            This should work on any modern Linux machine using libc.
+          files: |
+            ./SHA256SUMS.txt
+            ./imaptest.tgz

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,7 +16,8 @@ export default defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: 'Home', link: '/' },
-      { text: 'Configuration', link: '/configuration' }
+      { text: 'Configuration', link: '/configuration' },
+      { text: 'Download', link: '/download' },
     ],
 
     sidebar: [
@@ -31,6 +32,7 @@ export default defineConfig({
       {
         text: 'Installation',
         items: [
+          { text: 'Download', link: '/download' },
           { text: 'Installation', link: '/installation' },
         ]
       },

--- a/docs/download.md
+++ b/docs/download.md
@@ -4,6 +4,16 @@ layout: doc
 
 # ImapTest Download
 
+## Linux packages
+
+The [Dovecot Team](https://dovecot.org/) creates ImapTest packages for
+several different Linux distributions.
+
+Instructions on how to configure your system to install the packages can be
+found on the [Dovecot Community Repositories](https://repo.dovecot.org/) page.
+
+## Static Binaries ("latest")
+
 Static binaries are automatically compiled whenever a commit is pushed to
 the source repository.
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,0 +1,15 @@
+---
+layout: doc
+---
+
+# ImapTest Download
+
+Static binaries are automatically compiled whenever a commit is pushed to
+the source repository.
+
+**Download link: https://github.com/dovecot/imaptest/releases/tag/latest**
+
+::: info
+ImapTest can also be compiled from source. See [Installation](/installation)
+for details.
+:::


### PR DESCRIPTION
Generate a static build of imaptest and upload it to github.  Essentially a nightly.  Allows use of imaptest without having to do extra compilation work.