### PR TITLE
Add support for sending REPLACE commands in test scripts

### DIFF
--- a/src/client-state.h
+++ b/src/client-state.h
@@ -91,6 +91,8 @@ void client_state_add_to_timer(enum client_state state,
 
 int imap_client_append(struct imap_client *client, const char *args, bool add_datetime,
 		       command_callback_t *callback, struct command **cmd_r);
+int imap_client_replace(struct imap_client *client, bool uid, const char *args,
+			command_callback_t *callback, struct command **cmd_r);
 int imap_client_append_full(struct imap_client *client, const char *mailbox,
 			    const char *flags, const char *datetime,
 			    command_callback_t *callback, struct command **cmd_r);

--- a/src/test-exec.c
+++ b/src/test-exec.c
@@ -856,7 +856,7 @@ static void test_send_next_command(struct test_exec_context *ctx,
 				   struct test_command *test_cmd)
 {
 	struct command *cmd = NULL;
-	const char *cmdline;
+	const char *cmdline, *args;
 	unsigned int cmdline_len;
 
 	cmdline = test_cmd->command;
@@ -866,10 +866,10 @@ static void test_send_next_command(struct test_exec_context *ctx,
 		client->client.state = STATE_APPEND;
 		(void)imap_client_append_full(client, NULL, NULL, NULL,
 					      test_cmd_callback, &cmd);
-	} else if (strncasecmp(cmdline, "append ", 7) == 0 &&
-		   !append_has_body(ctx, cmdline+7, cmdline_len-7)) {
+	} else if (str_begins_icase(cmdline, "append ", &args) &&
+		   !append_has_body(ctx, args, strlen(args))) {
 		client->client.state = STATE_APPEND;
-		(void)imap_client_append(client, cmdline + 7, FALSE,
+		(void)imap_client_append(client, args, FALSE,
 					 test_cmd_callback, &cmd);
 	} else {
 		if (test_cmd->linenum == 0 ||


### PR DESCRIPTION
This is implemented as a modified APPEND command.
Full tests for IMAP REPLACE capability are not part of this commit. This is needed for Dovecot internal CI testing.