### PR TITLE
Misc fixes to get the project to compile on latest core

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,7 @@ AS_IF([test "$DOVECOT_INSTALLED" = 'no'], [
 	LIBDOVECOT_SSL=$abs_dovecotdir/src/lib-ssl-iostream/libssl_iostream_openssl.la
 ], [
 	LIBDOVECOT=$dovecot_pkglibdir/libdovecot.la
-	LIBDOVECOT_SSL=$dovecot_pkglibdir/libssl_iostream_openssl.la
+	LIBDOVECOT_SSL=$dovecot_moduledir/libssl_iostream_openssl.la
 ])
 AC_SUBST([LIBDOVECOT_SSL])
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -627,6 +627,7 @@ get_next_username(const struct profile_user *user_profile,
 			{ .key = "username_idx", .value = num, },
 			VAR_EXPAND_TABLE_END
 		},
+		.providers = NULL,
 	};
 	const char *line, *error;
 

--- a/src/user.c
+++ b/src/user.c
@@ -272,6 +272,7 @@ const char *user_get_new_mailbox(struct client *client)
 				{ .key = "client_idx", .value = dec2str(client->idx) },
 				VAR_EXPAND_TABLE_END
 			},
+			.providers = NULL,
 		};
 		const char *error;
 		string_t *str = t_str_new(32);


### PR DESCRIPTION
- Fix lookup for `libssl_iostream_openssl.la` in `configure.ac`,
- initialize `.providers` attribute in `var_expand_params` structs.