### PR TITLE
github: Use matrix.os instead of matrix.version

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Rename artifact
         run: |
           for n in ${{ join(fromJSON(matrix.aliases), ' ') }}; do cp imaptest/src/imaptest "imaptest-$(uname -m)-$n"; done
-          mv imaptest/src/imaptest imaptest-$(uname -m)-${{ matrix.version }}
+          mv imaptest/src/imaptest imaptest-$(uname -m)-${{ matrix.os }}
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Broken in e5a26d8229cfdbe26bc8d0bfe3c5f4e48b5601c3