### PR TITLE
github: Fix typo in ubuntu-20.04

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -108,7 +108,7 @@ jobs:
           - os: rhel8
             container: registry.access.redhat.com/ubi8/ubi
             stream: https://vault.centos.org/8-stream
-            aliases: '["debian-11","ubuntu20.04"]'
+            aliases: '["debian-11","ubuntu-20.04"]'
           - os: rhel9
             container: registry.access.redhat.com/ubi9/ubi
             stream: https://mirror.stream.centos.org/9-stream/


### PR DESCRIPTION
Broken in e5a26d8229cfdbe26bc8d0bfe3c5f4e48b5601c3