### PR TITLE
setting: Remove imap_status_interval

### DIFF
--- a/profile.conf
+++ b/profile.conf
@@ -104,7 +104,6 @@ client Thunderbird {
   imap_idle = yes
   imap_fetch_immediate = UID RFC822.SIZE FLAGS BODY.PEEK[HEADER.FIELDS (From To Cc Bcc Subject Date Message-ID Priority X-Priority References Newsgroups In-Reply-To Content-Type)]
   imap_fetch_manual = RFC822.SIZE BODY[]
-  imap_status_interval = 5 min
 }
 
 client AppleMail {
@@ -113,5 +112,4 @@ client AppleMail {
   imap_idle = yes
   imap_fetch_immediate = INTERNALDATE UID RFC822.SIZE FLAGS BODY.PEEK[HEADER.FIELDS (date subject from to cc message-id in-reply-to references x-priority x-uniform-type-identifier x-universally-unique-identifier)] MODSEQ
   imap_fetch_manual = BODYSTRUCTURE BODY.PEEK[]
-  imap_status_interval = 5 min
 }

--- a/src/profile-parse.c
+++ b/src/profile-parse.c
@@ -38,7 +38,6 @@ static const struct setting_define profile_client_setting_defines[] = {
 	DEF(BOOL, imap_idle),
 	DEF(STR, imap_fetch_immediate),
 	DEF(STR, imap_fetch_manual),
-	DEF(TIME, imap_status_interval),
 	DEF(TIME, login_interval),
 
 	SETTING_DEFINE_LIST_END

--- a/src/profile.h
+++ b/src/profile.h
@@ -19,7 +19,6 @@ struct profile_client {
 	bool imap_idle;
 	const char *imap_fetch_immediate;
 	const char *imap_fetch_manual;
-	unsigned int imap_status_interval;
 	unsigned int login_interval;
 };
 ARRAY_DEFINE_TYPE(profile_client, struct profile_client *);


### PR DESCRIPTION
It has never been used since the setting was added

Issue #23