### PR TITLE
Fix crash when running without mail session timeout

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -457,6 +457,8 @@ static int user_timestamp_handle(struct user *user, enum user_timestamp ts,
 		} else if (ts == USER_TIMESTAMP_LOGOUT && user_connected) {
 			/* have to have a logout timestamp when there are
 			   connected clients. */
+			if (user->profile->mail_session_length == 0)
+				return -1;
 			user->timestamps[ts] =
 				user_get_next_timeout(user, ioloop_time, ts);
 			i_assert(user->timestamps[ts] > 0);


### PR DESCRIPTION
imaptest can crash if run without mail session timeout, because LOGOUT timestamp is set to -1 in user_fill_timestamps() and not set to anything else later on. This was causing an assertion failure in user_timestamp_handle(). The fix is to add a check to ensure mail_session_length is greater than zero before setting the logout timestamp.

Issue #13 