### PR TITLE
Fix assertion failure in client_update_plan() during disconnect

### DIFF
--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -263,6 +263,14 @@ static void checkpoint_send_state_cmd(struct mailbox_storage *storage,
 		if (client == NULL || client->checkpointing != storage)
 			continue;
 
+		/* Skip clients that are already disconnecting or no longer selected,
+		 * preventing the redundant queuing of checkpoint commands that would
+		 * otherwise be immediately discarded. */
+		if (disconnect_clients || client->client.login_state != LSTATE_SELECTED) {
+			client->checkpointing = NULL;
+			continue;
+		}
+
 		/* send the checkpoint command */
 		client->plan[0] = state;
 		client->plan_size = 1;

--- a/src/client-state.c
+++ b/src/client-state.c
@@ -138,8 +138,13 @@ static enum client_state client_eat_first_plan(struct imap_client *client)
 {
 	enum client_state state;
 
-	if (disconnect_clients)
+	if (disconnect_clients) {
+		/* Clear the remaining plan to prevent an assertion failure in
+		 * client_update_plan() when the client transitions to
+		 * LSTATE_NONAUTH. */
+		client->plan_size = 0;
 		return STATE_LOGOUT;
+	}
 
 	i_assert(client->plan_size > 0);
 	state = client->plan[0];


### PR DESCRIPTION
Fixes this issue:

Running the command imaptest "host=127.0.0.1" "port=31143" "user=test1" "user2=test2" "secs=1" "checkpoint=1" causes this crash:

Panic: file client-state.c: line 235 (client_update_plan): assertion failed: (client->plan_size == 0)
Error: Raw backtrace: imaptest(+0x9c002) [0x62623f271002] -> imaptest(+0x9c136) [0x62623f271136] ->
imaptest(+0x5a69e) [0x62623f22f69e] -> imaptest(+0x5a6e7) [0x62623f22f6e7] -> imaptest(+0x1144a)
[0x62623f1e644a] -> imaptest(+0xc9d2) [0x62623f1e19d2] -> imaptest(+0x1dddf) [0x62623f1f2ddf] ->
imaptest(+0x1c570) [0x62623f1f1570] -> imaptest(+0x231a2) [0x62623f1f81a2] -> imaptest(+0x1db31)
[0x62623f1f2b31] -> imaptest(+0x5f01d) [0x62623f23401d] -> imaptest(+0x9f76a) [0x62623f27476a] ->
imaptest(+0x5f0c4) [0x62623f2340c4] -> imaptest(+0x5f2a0) [0x62623f2342a0] -> imaptest(+0x1bacb)
[0x62623f1f0acb] -> libc.so.6(+0x2a1ca) [0x77e2ba62a1ca] -> libc.so.6(__libc_start_main+0x8b)
[0x77e2ba62a28b] -> imaptest(+0x1c085) [0x62623f1f1085]