### PR TITLE
github: Check for dependency updates in github actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  # Checks for dependency updates in github actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
We are getting npm version deprecation warnings in github action builds, so let's just add this and fix whatever it finds (yes, i'm lazy)