### PR TITLE
test: Add !ordered directive for untagged replies

### DIFF
--- a/docs/scripted_test.md
+++ b/docs/scripted_test.md
@@ -365,6 +365,24 @@ ok some-command
 ok next-command
 ```
 
+### Untagged reply order
+
+| Directive | Description |
+| --- | --- |
+| `!ordered` | Require the untagged replies of this command to be received in the same order as they are listed. |
+
+By default the untagged replies may be received in any order. With
+`!ordered` a reply is matched only against the first expected reply that
+hasn't been matched yet, so replies arriving in the wrong order are reported
+as missing.
+
+```
+ok noop
+!ordered
+* LIST () "." foo
+* LIST (\NonExistent) "." foo
+```
+
 ### Output
 
 | Directive | Description |

--- a/src/test-exec.c
+++ b/src/test-exec.c
@@ -719,9 +719,14 @@ test_handle_untagged_match(struct imap_client *client, const struct imap_arg *ar
 				return;
 			}
 			found[i] = 1;
-			/* continue - we may want to match more */
 			found_some = TRUE;
 			array_clear(&ctx->added_variables);
+			if ((*groupp)->untagged_ordered) {
+				/* this reply matched the next expected reply -
+				   don't let it match the later ones */
+				break;
+			}
+			/* continue - we may want to match more */
 			continue;
 		}
 		if (maybes[i].count < match_count) {
@@ -735,6 +740,14 @@ test_handle_untagged_match(struct imap_client *client, const struct imap_arg *ar
 		for (j = 0; j < var_count; j++)
 			hash_table_remove(ctx->variables, vars[j]);
 		array_clear(&ctx->added_variables);
+
+		if ((*groupp)->untagged_ordered &&
+		    untagged[i].existence == TEST_EXISTENCE_MUST_EXIST) {
+			/* the next required reply didn't match, so this reply
+			   is out of order. Don't match it against the later
+			   replies - they are reported as missing instead. */
+			break;
+		}
 	}
 	if (!found_some) {
 		ctx->cur_untagged_mismatch_count++;

--- a/src/test-parser.c
+++ b/src/test-parser.c
@@ -604,6 +604,10 @@ test_parse_command_line(struct test_parser *parser, struct test *test,
 			array_append(&group->output, &output, 1);
 			return TRUE;
 		}
+		if (strcmp(line, "!ordered") == 0) {
+			group->untagged_ordered = TRUE;
+			return TRUE;
+		}
 
 		if (test_is_untagged(line, &existence)) {
 			/* parse untagged replies (*, !, ?) */

--- a/src/test-parser.h
+++ b/src/test-parser.h
@@ -61,6 +61,9 @@ struct test_command_group {
 	unsigned int sleep_msecs;
 	/* TRUE if one of the untagged replies is a BYE */
 	bool have_untagged_bye;
+	/* TRUE if the untagged replies must be received in the same order as
+	   they are listed in the test script */
+	bool untagged_ordered;
 };
 
 struct test_connection {


### PR DESCRIPTION
Untagged replies are matched in any order, so a test can't verify that the server sends them in the order the protocol requires. With !ordered a reply is matched only against the first expected reply that hasn't been matched yet, so replies arriving in the wrong order are reported as missing.